### PR TITLE
Ne pas crash si l'adresse MAC manque

### DIFF
--- a/src/sysbus/manuf.py
+++ b/src/sysbus/manuf.py
@@ -191,7 +191,7 @@ class MacParser(object):
 
         """
         vendors = []
-        if maximum <= 0:
+        if maximum <= 0 or not mac:
             return vendors
         mac_str = self._strip_mac(mac)
         mac_int = self._get_mac_int(mac_str)


### PR DESCRIPTION
Je ne sais pas pourquoi, mais sur mon réseau, la commande `-hosts` tentait de lister des appareils sans adresse MAC associée. Le code de `hosts_cmd` est robuste à cela, mais pas le code de `search`.